### PR TITLE
CASMCMS-8041: Correct minor spelling errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Spelling corrections.
+
 ## [1.4.0] - 2022-08-10
 ### Changed
 - Convert to gitflow/gitversion.

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -37,7 +37,7 @@ pipeline {
     environment {
         NAME = "cray-k8s-liveness"
         PYMOD_NAME = "liveness"
-        DESCRIPTION = "Library for creating and referncing timestamps to determine if a piece of code is running or not, from a k8s perspective"
+        DESCRIPTION = "Library for creating and referencing timestamps to determine if a piece of code is running or not, from a k8s perspective"
         IS_STABLE = getBuildIsStable()
     }
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # k8s-liveness
 
 This is the K8s-liveness project; it contains a basic library for creating
-and referncing timestamps in order to determine if a piece of code is running
+and referencing timestamps in order to determine if a piece of code is running
 or not, from a k8s perspective.
 
 The base class, `Timestamp`, is intended to be inherited. Each project

--- a/src/liveness/timestamp.py
+++ b/src/liveness/timestamp.py
@@ -77,7 +77,7 @@ class Timestamp(object):
             with open(self.path, 'r') as timestamp_file:
                 return datetime.fromtimestamp(float(timestamp_file.read().strip()))
         except FileNotFoundError:
-            LOGGER.warning("Timestamp never intialized to '%s'" % (self.path))
+            LOGGER.warning("Timestamp never initialized to '%s'" % (self.path))
             return datetime.fromtimestamp(0)
         except ValueError:
             # CASMCMS-6856: There is an edgecase where backgrounded writes of a timestamp


### PR DESCRIPTION
## Summary and Scope

Correct spelling errors / typos in the repo. They have not caused any reported problems, but we may as well fix them. No need to make a manifest PR, though -- these can just get picked up the next time we make a release.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
