### PR TITLE
Update Jenkinsfile to reduce chances of hung or failed builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Spelling corrections.
+- Disabled concurrent Jenkins builds on same branch/commit
+- Added build timeout to avoid hung builds
 
 ### Removed
 - Removed defunct files leftover from previous versioning system

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),
@@ -32,6 +32,8 @@ pipeline {
     }
     options {
         buildDiscarder(logRotator(numToKeepStr: "10"))
+        disableConcurrentBuilds()
+        timeout(time: 90, unit: 'MINUTES')
         timestamps()
     }
     environment {


### PR DESCRIPTION
Based on a suggestion made by David, this updates the Jenkinsfile to effect two changes:
- Disable concurrent builds of the same tag or commit
- Add a timeout (90 minutes) as a safeguard against hung builds

These options are used in many other repos in our org to good effect.